### PR TITLE
[40기 윤형준] ADD: DB Migration file 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+transferData.js
+data_folder
 .env
 node_modules/
 db/schema.sql

--- a/db/migrations/20221225142824_movies.sql
+++ b/db/migrations/20221225142824_movies.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+CREATE TABLE movies (
+    id INT NOT NULL AUTO_INCREMENT, 
+    title VARCHAR(200) NOT NULL,
+    title_eng VARCHAR(200) NOT NULL,
+    duration_min INT NOT NULL,
+    age_limit INT NOT NULL,
+    opening_date VARCHAR(500) NOT NULL, 
+    descriptions TEXT NOT NULL,
+    thumbnail_image_url TEXT NOT NULL,
+    director VARCHAR(100) NOT NULL,
+    price DECIMAL(8,2) NOT NULL,
+    actors VARCHAR(1000) NOT NULL,
+    trailer_videos_url TEXT NOT NULL,
+    still_cut_image TEXT NOT NULL,
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE movies;

--- a/db/migrations/20221227051301_theater.sql
+++ b/db/migrations/20221227051301_theater.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE theater (
+    id INT NOT NULL AUTO_INCREMENT, 
+    name VARCHAR(300),
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE theater;

--- a/db/migrations/20221227051310_hall.sql
+++ b/db/migrations/20221227051310_hall.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE hall (
+    id INT NOT NULL AUTO_INCREMENT, 
+    hall_name VARCHAR(300),
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE hall;

--- a/db/migrations/20221227051341_movie_date.sql
+++ b/db/migrations/20221227051341_movie_date.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE movie_date (
+    id INT NOT NULL AUTO_INCREMENT, 
+    date DATE,
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE movie_date;

--- a/db/migrations/20221227051351_movie_time.sql
+++ b/db/migrations/20221227051351_movie_time.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE movie_time (
+    id INT NOT NULL AUTO_INCREMENT, 
+    movie_time time,
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE movie_time;

--- a/db/migrations/20221227051404_seat_row.sql
+++ b/db/migrations/20221227051404_seat_row.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE seat_row (
+    id INT NOT NULL AUTO_INCREMENT, 
+    row_name VARCHAR(4),
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE seat_row;

--- a/db/migrations/20221227051415_seat_number.sql
+++ b/db/migrations/20221227051415_seat_number.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE seat_number (
+    id INT NOT NULL AUTO_INCREMENT, 
+    seat_number INT,
+    PRIMARY KEY (id)
+)
+
+-- migrate:down
+DROP TABLE seat_number;

--- a/db/migrations/20221227051420_seat.sql
+++ b/db/migrations/20221227051420_seat.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+CREATE TABLE seat (
+    id INT NOT NULL AUTO_INCREMENT, 
+    row_id INT,
+    number_id INT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (row_id) REFERENCES seat_row(id),
+    FOREIGN KEY (number_id) REFERENCES seat_number(id)
+)
+
+-- migrate:down
+DROP TABLE seat;

--- a/db/migrations/20221227054848_screen.sql
+++ b/db/migrations/20221227054848_screen.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+CREATE TABLE screen (
+    id INT NOT NULL AUTO_INCREMENT, 
+    movie_id INT,
+    theater_id INT,
+    movie_date_id INT,
+    movie_time_id INT, 
+    hall_id INT,
+    seat_id INT,
+    PRIMARY KEY (id),
+    CONSTRAINT UC_screen UNIQUE (movie_id, theater_id, movie_date_id, movie_time_id, hall_id, seat_id),
+    FOREIGN KEY (movie_id) REFERENCES movies(id),
+    FOREIGN KEY (theater_id) REFERENCES theater(id),
+    FOREIGN KEY (movie_date_id) REFERENCES movie_date(id),
+    FOREIGN KEY (movie_time_id) REFERENCES movie_time(id),
+    FOREIGN KEY (hall_id) REFERENCES hall(id),
+    CONSTRAINT screen_seat_id_fkey FOREIGN KEY (seat_id) REFERENCES seat(id)
+)
+
+-- migrate:down
+DROP TABLE screen;

--- a/db/migrations/20221227092349_users.sql
+++ b/db/migrations/20221227092349_users.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+create table users(
+    id INT NOT NULL AUTO_INCREMENT,
+    nick_name VARCHAR(100) NULL,
+    email VARCHAR(100) NULL,
+    kakao_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT users_kakao_id_ukey UNIQUE(kakao_id),
+    PRIMARY KEY(id)
+)
+
+-- migrate:down
+DROP TABLE users

--- a/db/migrations/20221227092745_reservation.sql
+++ b/db/migrations/20221227092745_reservation.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+CREATE TABLE reservation (
+    id INT NOT NULL AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    screen_id INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY(id),
+    CONSTRAINT screen_uc UNIQUE (screen_id),
+    CONSTRAINT reservations_user_id_fkey FOREIGN KEY(user_id) REFERENCES users(id),
+    CONSTRAINT reservations_screen_id_fkey FOREIGN KEY(screen_id) REFERENCES screen(id)
+)
+
+-- migrate:down
+DROP TABLE reservation

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "typeorm": "^0.3.11"
       },
       "devDependencies": {
+        "csvtojson": "^2.0.10",
         "jest": "^29.3.1",
         "morgan": "^1.10.0",
         "nodemon": "^2.0.20",
@@ -1528,6 +1529,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "node_modules/body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -1994,6 +2001,35 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "bin": {
+        "csvtojson": "bin/csvtojson"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/csvtojson/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "dev": true,
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/date-fns": {
@@ -2872,6 +2908,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typeorm": "^0.3.11"
   },
   "devDependencies": {
+    "csvtojson": "^2.0.10",
     "jest": "^29.3.1",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.20",


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- DB Migration file 생성

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- ERD에 기반하여 Migration file 작성

<br />

## :: 수정 사항 
- users table에서 컬럼명 social_id를  kakao_id로 변경 및 데이터 타입 수정
- reservation_status table 삭제. 그에 따라 기존에 reservation_status table이 참조하고 있던 reservation table의 status_id 컬럼 삭제.
> 해당 테이블 삭제 이유: reservation_status table이 존재할 필요가 없음. 예약이 될시 reservation table에 데이터가 쌓이며 여기에 쌓이는 모든 데이터는 예약이 완료됨을 나타냄. (초기 ERD 기획의 오류) 

- 어떠한 좌석에 대해 중복 예약을 데이터 베이스 내에서 방지하기 해야함. 따라서 reservation table에 항상 unique한 screen_id만 존재할 수 있도록 screen_id에 대한 unique constraint 설정.
- migration file의 컬럼명 오타 수정.
- 데이터를 담고 있는 csv 파일을 mysql db에 덤핑하기 위한 코드 파일을 gitignore에 추가

